### PR TITLE
fix bug for adding snacks and drinks where there are not enough args

### DIFF
--- a/src/release/command/CmdAddSnacksDrinks.java
+++ b/src/release/command/CmdAddSnacksDrinks.java
@@ -68,7 +68,7 @@ public class CmdAddSnacksDrinks implements Command{
                     System.out.printf("[State] Successfully added %s, %s!%n%n", type, name);
                 }
 
-            } catch (ExInvalidOption e) {
+            } catch (ExInvalidOption | ExInsufficientArgs e) {
                 System.out.println(e.getMessage() + "\n");
             }
         }


### PR DESCRIPTION
This pull request includes a small change to the `CmdAddSnacksDrinks.java` file. The change improves error handling by catching an additional exception type.

* [`src/release/command/CmdAddSnacksDrinks.java`](diffhunk://#diff-fb33c9079896daaf787cc2347c77652a7e92079aa6bcff9eb9759360d13b56abL71-R71): Modified the `execute` method to catch `ExInsufficientArgs` in addition to `ExInvalidOption`.